### PR TITLE
Fix: foreign keys miss-referencing

### DIFF
--- a/SCA_DB_script.sql
+++ b/SCA_DB_script.sql
@@ -9,77 +9,48 @@ GO
 
 
 CREATE TABLE dbo.[Gender_Lookup] (
-  [ID] [int] IDENTITY (1,1) NOT NULL PRIMARY KEY,
+  [Gender_ID] [int] IDENTITY (1,1) NOT NULL PRIMARY KEY,
   [Gender_Description] [varchar](150) NOT NULL
 );
 GO
 
 CREATE TABLE dbo.[Race_Lookup] (
-  [ID] [int] IDENTITY (1,1) NOT NULL PRIMARY KEY,
+  [Race_ID] [int] IDENTITY (1,1) NOT NULL PRIMARY KEY,
   [Race_Description] varchar(150) NOT NULL
 );
 GO
 
 CREATE TABLE dbo.[User] (
-  [ID] INT IDENTITY (1,1) PRIMARY KEY NOT NULL,
+  [User_ID] INT IDENTITY (1,1) PRIMARY KEY NOT NULL,
   [Gender_ID] INT NOT NULL,
   [Race_ID] INT NOT NULL,
   [Phone_Number] varchar(15) NULL,
   [Age] INT NULL,
   CONSTRAINT [FK_User.Gender_ID]
     FOREIGN KEY ([Gender_ID])
-      REFERENCES [Gender_Lookup]([ID]),
+      REFERENCES [Gender_Lookup]([Gender_ID]),
   CONSTRAINT [FK_User.Race_ID]
     FOREIGN KEY ([Race_ID])
-      REFERENCES [Race_Lookup]([ID])
+      REFERENCES [Race_Lookup]([Race_ID])
 );
 GO
 
 CREATE TABLE dbo.[Assailant] (
-  [ID] INT IDENTITY (1,1) PRIMARY KEY NOT NULL,
+  [Assailant_ID] INT IDENTITY (1,1) PRIMARY KEY NOT NULL,
   [Race_ID] INT NOT NULL,
   [Gender_ID] INT NOT NULL,
   [Description] varchar(500) NULL,
   CONSTRAINT [FK_Assailant.Gender_ID]
     FOREIGN KEY ([Gender_ID])
-      REFERENCES [Gender_Lookup]([ID]),
+      REFERENCES [Gender_Lookup]([Gender_ID]),
   CONSTRAINT [FK_Assailant.Race_ID]
     FOREIGN KEY ([Race_ID])
-      REFERENCES [Race_Lookup]([ID])
-);
-GO
-
-CREATE TABLE dbo.[User] (
-  [ID] INT IDENTITY (1,1) PRIMARY KEY NOT NULL,
-  [Gender_ID] INT NOT NULL,
-  [Race_ID] INT NOT NULL,
-  [Phone_Number] varchar(15) NULL,
-  [Age] INT NULL,
-  CONSTRAINT [FK_User.Gender_ID]
-    FOREIGN KEY ([Gender_ID])
-      REFERENCES [Gender_Lookup]([ID]),
-  CONSTRAINT [FK_User.Race_ID]
-    FOREIGN KEY ([Race_ID])
-      REFERENCES [Race_Lookup]([ID])
-);
-GO
-
-CREATE TABLE dbo.[Assailant] (
-  [ID] INT IDENTITY (1,1) PRIMARY KEY NOT NULL,
-  [Race_ID] INT NOT NULL,
-  [Gender_ID] INT NOT NULL,
-  [Description] varchar(500) NULL,
-  CONSTRAINT [FK_Assailant.Gender_ID]
-    FOREIGN KEY ([Gender_ID])
-      REFERENCES [Gender_Lookup]([ID]),
-  CONSTRAINT [FK_Assailant.Race_ID]
-    FOREIGN KEY ([Race_ID])
-      REFERENCES [Race_Lookup]([ID])
+      REFERENCES [Race_Lookup]([Race_ID])
 );
 GO
 
 CREATE TABLE [Area] (
-  [AreaID] [int] IDENTITY(1,1) PRIMARY KEY NOT NULL,
+  [Area_ID] [int] IDENTITY(1,1) PRIMARY KEY NOT NULL,
   [ZIP_Code] [int],
   [Suburb] [varchar](150),
   [City] [varchar](150) ,
@@ -89,8 +60,8 @@ GO
 
 
 CREATE TABLE [Location] (
-  [LocationID] [int] IDENTITY(1,1) PRIMARY KEY NOT NULL,
-  [Area_Code_ID] [int] FOREIGN KEY REFERENCES [Area]([AreaID]) NOT NULL,
+  [Location_ID] [int] IDENTITY(1,1) PRIMARY KEY NOT NULL,
+  [Area_Code_ID] [int] FOREIGN KEY REFERENCES [Area]([Area_ID]) NOT NULL,
   [Street_Number] [int],
   [Street_Name] [varchar](250),
   [Latitude] [decimal](10,6),
@@ -100,7 +71,7 @@ GO
 
 
 CREATE TABLE dbo.[Incident] (
-  [ID] INT IDENTITY (1,1) NOT NULL PRIMARY KEY,
+  [Incident_ID] INT IDENTITY (1,1) NOT NULL PRIMARY KEY,
   [User_ID] INT NOT NULL,
   [Location_ID] INT NOT NULL,
   [Date] DATE NOT NULL,
@@ -108,15 +79,15 @@ CREATE TABLE dbo.[Incident] (
   [Description] varchar(150) NOT NULL,
   CONSTRAINT [FK_Incident.Location_ID]
     FOREIGN KEY ([Location_ID])
-      REFERENCES [Location]([ID]),
+      REFERENCES [Location]([Location_ID]),
   CONSTRAINT [FK_Incident.User_ID]
     FOREIGN KEY ([User_ID])
-      REFERENCES [User]([ID])
+      REFERENCES [User]([User_ID])
 );
 GO
 
 CREATE TABLE dbo.[Incident_Type] (
-  [ID] INT IDENTITY (1,1) NOT NULL PRIMARY KEY,
+  [Incident_Type_ID] INT IDENTITY (1,1) NOT NULL PRIMARY KEY,
   [Incident_Description] varchar(150)
 );
 GO
@@ -126,10 +97,10 @@ CREATE TABLE [Assailant_Incident] (
   [Incident_ID] [int],
   CONSTRAINT [FK_Assailant_Incident.Incident_ID]
     FOREIGN KEY ([Incident_ID])
-      REFERENCES [Incident]([ID]),
+      REFERENCES [Incident]([Incident_ID]),
   CONSTRAINT [FK_Assailant_Incident.Assailant_ID]
     FOREIGN KEY ([Assailant_ID])
-      REFERENCES [Assailant]([ID])
+      REFERENCES [Assailant]([Assailant_ID])
 );
 GO
 
@@ -138,10 +109,10 @@ CREATE TABLE [Incident_Report] (
   [Incident_Type_ID] [int],
   CONSTRAINT [FK_Incident_Report.Incident_ID]
     FOREIGN KEY ([Incident_ID])
-      REFERENCES [Incident]([ID]),
+      REFERENCES [Incident]([Incident_ID]),
   CONSTRAINT [FK_Incident_Report.Incident_Type_ID]
     FOREIGN KEY ([Incident_Type_ID])
-      REFERENCES [Incident_Type]([ID])
+      REFERENCES [Incident_Type]([Incident_Type_ID])
 );
 GO
 
@@ -153,7 +124,7 @@ CREATE TABLE [Hospital] (
   PRIMARY KEY ([ID]),
   CONSTRAINT [FK_Hospital.Location_ID]
     FOREIGN KEY ([Location_ID])
-      REFERENCES [Location]([LocationID]),
+      REFERENCES [Location]([Location_ID]),
 );
 GO
 
@@ -165,6 +136,6 @@ CREATE TABLE [SAPS] (
   PRIMARY KEY ([ID]),
   CONSTRAINT [FK_SAPS.Location_ID]
     FOREIGN KEY ([Location_ID])
-      REFERENCES [Location]([LocationID]),
+      REFERENCES [Location]([Location_ID]),
 );
 GO


### PR DESCRIPTION
I standardised the ID names in our tables, such that each ID is "{table_name}_ID". The tables now reference one another correctly. 
I also removed 2 repeated table definitions.